### PR TITLE
Ensure we always have a client configuration

### DIFF
--- a/aws-android-sdk-apigateway-core/src/main/java/com/amazonaws/mobileconnectors/apigateway/ApiClientFactory.java
+++ b/aws-android-sdk-apigateway-core/src/main/java/com/amazonaws/mobileconnectors/apigateway/ApiClientFactory.java
@@ -123,15 +123,17 @@ public class ApiClientFactory {
     /**
      * Gets an invocation handler for the given API.
      *
-     * @param apiClass API class
+     * @param endpoint Request endpoint
+     * @param apiName API class name
      * @return an invocation handler
      */
     ApiClientHandler getHandler(String endpoint, String apiName) {
         Signer signer = provider == null ? null : getSigner(getRegion(endpoint));
 
-        ApiClientHandler handler = new ApiClientHandler(
-                endpoint, apiName, signer, provider, apiKey, clientConfiguration);
-        return handler;
+        // Ensure we always pass a configuration to the handler
+        ClientConfiguration configuration = (clientConfiguration == null) ? new ClientConfiguration() : clientConfiguration;
+
+        return new ApiClientHandler(endpoint, apiName, signer, provider, apiKey, configuration);
     }
 
     /**


### PR DESCRIPTION
The amazon aws core doesn't work without a client configuration. Previously, we had a scenario where we would be passing a ``null`` client configuration which resulted in some hidden and dark errors.

This PR prevents this scenario by checking if the client configuration is ``null`` and if so creating a default one. The AWS core already guarantees that when you do ``new ClientConfiguration()`` all default values are initialised.